### PR TITLE
chore: add prettier settings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,13 @@
       "!src/*.d.ts"
     ]
   },
+  "prettier": {
+    "printWidth": 80,
+    "semi": true,
+    "singleQuote": false,
+    "bracketSpacing": true,
+    "trailingComma": "es5"
+  },
   "devDependencies": {
     "@babel/core": "^7.9.6",
     "@babel/plugin-proposal-object-rest-spread": "^7.9.6",


### PR DESCRIPTION
## What

Adds my best guess as to what your local `prettier` settings are based on the existing formatting.

## Why

Since no `prettier` settings exist in the project despite it being used in `lint-staged` and `eslint`, it'll use whatever `prettier` settings any of us have locally, which is probably not what you were wanting! 😃 

Great work btw! 🥳 Really excited to play around with this!