### PR TITLE
fix: ResizeObserver loop limit exceeded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ const useDimensions = <T extends HTMLElement | null>({
     // eslint-disable-next-line compat/compat
     observerRef.current = new (polyfill || window.ResizeObserver)(
       ([entry]: any) => {
-        window.requestAnimationFrame(() => {
+        rafId = window.requestAnimationFrame(() => {
           const { contentBoxSize, borderBoxSize, contentRect } = entry;
 
           let boxSize = contentBoxSize;
@@ -166,17 +166,13 @@ const useDimensions = <T extends HTMLElement | null>({
             breakpoints &&
             updateOnBreakpointChange
           ) {
-            rafId = requestAnimationFrame(() => {
-              setState((prev) =>
-                prev.currentBreakpoint !== next.currentBreakpoint ? next : prev
-              );
-            });
+            setState((prev) =>
+              prev.currentBreakpoint !== next.currentBreakpoint ? next : prev
+            );
             return;
           }
 
-          rafId = requestAnimationFrame(() => {
-            setState(next);
-          });
+          setState(next);
         })
     });
 
@@ -184,7 +180,7 @@ const useDimensions = <T extends HTMLElement | null>({
 
     return () => {
       unobserve();
-      if (rafId) cancelAnimationFrame(rafId);
+      if (rafId) window.cancelAnimationFrame(rafId);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [


### PR DESCRIPTION
<!--
  Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

  Before submitting a pull request, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

  Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

  If you're new to contributing to open source projects, you might find this free video course helpful: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github

  Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What

Since Chrome 64, the ResizeObserver is firing a silent error that might be captured and raised when adding an event listener to the window (like some UI error handlers do).

See [this GitHub discussion](https://github.com/souporserious/react-measure/issues/104).

For index.ts, this can be fixed as follows:

```
// eslint-disable-next-line compat/compat
    observerRef.current = new (polyfill || window.ResizeObserver)(
      ([entry]: any) => {
        window.requestAnimationFrame(() => { /* < New line */
```

## Why

For environments where UI error handlers that installing listeners, a ton of error messages are shown.

## How

I've added the suggested `requestAnimationFrame()` method.

## Checklist

Have you done all of these things?

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
