### PR TITLE
Fix example for throttled onResize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,15 +184,20 @@ const App = () => {
 
 ## Performance Optimization
 
-The `onResize` event will be triggered whenever the size of the target element is changed. We can reduce the frequency of the event callback by activating the [responsive mode](#responsive-components) or implementing our own throttled/debounced function as below.
+The `onResize` event will be triggered whenever the size of the target element is changed. We can reduce the frequency of the event callback by activating the [responsive mode](#responsive-components) or implementing our own throttled/debounced function as below. Note that in order to throttle/debounce the function correctly, it will need to be memoised else it will be recreated on every render call.
 
 ```js
 import _ from "lodash";
+import { useMemo } from 'react';
 
 const returnObj = useDimensions({
-  onResize: _.throttle(() => {
-    // Triggered once per every 500 milliseconds
-  }, 500),
+  onResize: useMemo(
+    () =>
+      _.throttle(() => {
+        // Triggered once per every 500 milliseconds
+      }, 500),
+    []
+  ),
 });
 ```
 


### PR DESCRIPTION
## What

Amend the example in the Performance Optimization section of the docs to memoise the throttled function

## Why

The example in the docs does not function as described. To throttle/debounce inside a react component the debounced function must [remain the same between component re-renders](https://dmitripavlutin.com/react-throttle-debounce/) In the example as written, the onResize function is still called every time the component re-renders (is resized).

## How

I've updated the example to show a method of effectively throttling the onResize function by using `useMemo` to memoize the function.

## Checklist

Have you done all of these things?

- [x] Documentation added
- [ ] Tests n/a
- [ ] TypeScript definitions updated n/a
- [x] Ready to be merged
